### PR TITLE
Bump dependencies in idf_component.yml

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,8 +1,8 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zigbee-lib: "~0.9.0"
-  espressif/esp-zboss-lib: "~0.7.0"
+  espressif/esp-zigbee-lib: "~1.1.2"
+  espressif/esp-zboss-lib: "~1.1.2"
   espressif/led_strip: "~2.0.0"
   ## Required IDF version
   idf:
-    version: ">=5.0.0"
+    version: ">=5.1.2"


### PR DESCRIPTION
esp-zigbee-sdk currently works with ESP-IDF release/v5.1 branch.